### PR TITLE
Replaced snapshot dependency with stable github dependency on iotaz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val assemblySettings = Seq(
 )
 
 // Build and publish a project, excluding its tests.
-lazy val commonSettings = buildSettings ++ publishSettings ++ assemblySettings
+lazy val commonSettings = buildSettings ++ publishSettings ++ assemblySettings ++ (cancelable := false)
 
 // not doing this causes NoSuchMethodErrors when using coursier
 lazy val excludeTypelevelScalaLibrary =
@@ -287,6 +287,7 @@ lazy val root = project.in(file("."))
   * like to push to upstream libraries.
   */
 lazy val foundation = project
+  .gitHubDependency("frees-io", "iota", "e77a8be", Some("corezJVM"))   // TODO replace this with a real dependency once they release
   .settings(name := "quasar-foundation-internal")
   .settings(commonSettings)
   .settings(publishTestsSettings)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,6 @@ object Dependencies {
     "com.chuusai"                %% "shapeless"                 % shapelessVersion,
     "org.scalacheck"             %% "scalacheck"                % scalacheckVersion,
     "com.propensive"             %% "contextual"                % "1.0.1",
-    "io.frees"                   %% "iotaz-core"                % "0.3.8-SNAPSHOT",
     "com.github.mpilquist"       %% "simulacrum"                % simulacrumVersion                    % Test,
     "org.typelevel"              %% "algebra-laws"              % algebraVersion                       % Test,
     "org.typelevel"              %% "discipline"                % disciplineVersion                    % Test,

--- a/project/Precog.scala
+++ b/project/Precog.scala
@@ -70,6 +70,7 @@ object Build {
       serialTests scalacPlugins (kindProjector) scalacArgs (defaultArgSet: _*) also(
         organization := "org.quasar-analytics",
         scalaVersion := "2.12.4",
-        logBuffered in Test := false))
+        logBuffered in Test := false,
+        cancelable := false))
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,6 @@ addSbtPlugin("io.get-coursier"       % "sbt-coursier"  % "1.1.0-M1")
 addSbtPlugin("com.slamdata"          % "sbt-slamdata"  % "0.8.5")
 addSbtPlugin("pl.project13.scala"    % "sbt-jmh"       % "0.2.27")
 addSbtPlugin("com.github.romanowski" % "hoarder"       % "1.0.2-RC2")
+
+// don't look, don't look, don't look...
+addSbtPlugin("com.codecommit" % "sbt-evil-mode" % "0.1-bdad513")


### PR DESCRIPTION
This is just for build reproducibility. `-SNAPSHOT` dependencies aren't usable.